### PR TITLE
Add manifest consistency tests

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,12 +7,12 @@
     "theme_color": "#5e5c64",
     "icons": [
       {
-        "src": "icons/icon-192x192.png",
+        "src": "icon-192x192.png",
         "sizes": "192x192",
         "type": "image/png"
       },
       {
-        "src": "icons/icon-512x512.png",
+        "src": "icon-512x512.png",
         "sizes": "512x512",
         "type": "image/png"
       }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "miniature-waddle",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node tests/manifest.test.js"
+  }
+}

--- a/tests/manifest.test.js
+++ b/tests/manifest.test.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+
+const manifestPath = path.join(__dirname, '..', 'manifest.json');
+const manifestData = fs.readFileSync(manifestPath, 'utf-8');
+let manifest;
+try {
+  manifest = JSON.parse(manifestData);
+} catch (err) {
+  throw new Error('manifest.json is not valid JSON');
+}
+
+assert(Array.isArray(manifest.icons), 'manifest.icons should be an array');
+
+manifest.icons.forEach(icon => {
+  assert(typeof icon.src === 'string', 'icon.src should be a string');
+  const iconPath = path.join(path.dirname(manifestPath), icon.src);
+  if (!fs.existsSync(iconPath)) {
+    throw new Error(`Icon file missing: ${icon.src}`);
+  }
+});
+
+console.log('Manifest icon tests passed');


### PR DESCRIPTION
## Summary
- add a basic Node.js test for validating manifest icons
- ensure `manifest.json` points to existing icons
- add `package.json` with `npm test` script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f5a4ca2108329a97540c72acfc1b8